### PR TITLE
bugfix: Replace 422 IDENTIFIER_MISMATCH with eSIM API specific code

### DIFF
--- a/code/API_definitions/esim-profile-management.yaml
+++ b/code/API_definitions/esim-profile-management.yaml
@@ -24,9 +24,11 @@ info:
     ## Operation-Specific Identification
 
     - **Download**: Requires EID (target device) and activationCode. ICCID is assigned during download and returned in response.
-    - **Enable/Disable/Delete**: Requires only ICCID
-    - **Set-Fallback**: Requires only ICCID
-    - **Status**: Accepts either EID (all profiles on device) or ICCID (specific profile)
+    - **Enable/Disable/Delete**: Requires ICCID; EID may optionally be supplied to identify the target eUICC directly.
+    - **Set-Fallback**: Requires ICCID; EID may optionally be supplied to identify the target eUICC directly.
+    - **Status**: Accepts EID (all profiles on device), ICCID (specific profile), or both (specific profile, pairing asserted)
+
+    The ICCID identifies the target eSIM Profile; supplying the EID as well is always optional. It serves two purposes: as a routing hint, letting the provider act on the target device directly without first resolving which device holds the ICCID (a step IoT deployments often avoid to conserve device data and energy); and as a defensive assertion of the pairing. If the ICCID is not installed on the identified EID, the request is rejected with `422 ESIM_PROFILE_MANAGEMENT.IDENTIFIER_MISMATCH`. See the API documentation for details.
 
     # Operation Lifecycle
 
@@ -441,7 +443,7 @@ paths:
 
         This operation uses POST despite being a read operation. Device identifiers (EID/ICCID) are passed in the request body rather than as URL parameters to prevent their exposure in server logs, proxy caches, and browser history.
 
-        **eSIM Profile Identification**: Accepts either EID (all profiles on device) or ICCID (specific profile)
+        **eSIM Profile Identification**: Accepts EID (all profiles on device), ICCID (specific profile), or both (specific profile, with the EID/ICCID pairing asserted)
       operationId: getEsimProfileStatus
       security:
         - openId:
@@ -606,10 +608,14 @@ components:
           $ref: '#/components/schemas/ESimProfileIccid'
 
     ESimProfileForDownload:
-      allOf:
-        - $ref: '#/components/schemas/ESimProfile'
-        - required: [eid]
-      description: eSIM Profile identification for download operations (requires only EID, ICCID will be assigned during download)
+      type: object
+      properties:
+        eid:
+          $ref: '#/components/schemas/ESimProfileEid'
+      required:
+        - eid
+      additionalProperties: false
+      description: eSIM Profile identification for download operations. Only the EID is accepted; the ICCID is assigned during download and returned in the response.
 
     ESimProfileForOperation:
       allOf:
@@ -623,7 +629,7 @@ components:
         - anyOf:
             - required: [eid]
             - required: [iccid]
-      description: eSIM Profile identification for status operations (requires either EID or ICCID)
+      description: eSIM Profile identification for status operations (requires EID, ICCID, or both)
     # Request schemas using new eSIM Profile identification
     DownloadEsimProfileRequest:
       type: object

--- a/code/API_definitions/esim-profile-management.yaml
+++ b/code/API_definitions/esim-profile-management.yaml
@@ -369,7 +369,7 @@ paths:
       description: |
         Configures an eSIM Profile as fallback (backup) profile for automatic enabling if primary profiles fail. The eSIM Profile must be in DISABLED state.
 
-        **Identification**: The ICCID identifies the target eSIM Profile to designate as fallback. The EID, when supplied, identifies the eUICC on which to set the fallback. When both are provided and the ICCID is not installed on the identified eUICC, the request is rejected with `422 IDENTIFIER_MISMATCH`.
+        **Identification**: The ICCID identifies the target eSIM Profile to designate as fallback. The EID, when supplied, identifies the eUICC on which to set the fallback. When both are provided and the ICCID is not installed on the identified eUICC, the request is rejected with `422 ESIM_PROFILE_MANAGEMENT.IDENTIFIER_MISMATCH`.
 
         **State Transition**: No state change (sets attribute only)
         **Required**: ICCID (target eSIM Profile). **Optional**: EID (target eUICC).
@@ -800,7 +800,7 @@ components:
                   code:
                     enum:
                       - SERVICE_NOT_APPLICABLE
-                      - IDENTIFIER_MISMATCH
+                      - ESIM_PROFILE_MANAGEMENT.IDENTIFIER_MISMATCH
           examples:
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
@@ -812,5 +812,5 @@ components:
               description: The provided EID and ICCID are each individually valid, but the ICCID does not correspond to an eSIM Profile installed on the eUICC identified by the EID
               value:
                 status: 422
-                code: IDENTIFIER_MISMATCH
+                code: ESIM_PROFILE_MANAGEMENT.IDENTIFIER_MISMATCH
                 message: The provided ICCID is not associated with the provided EID.

--- a/documentation/API_documentation/eSIM-Profile-Management_GeneralDescription.md
+++ b/documentation/API_documentation/eSIM-Profile-Management_GeneralDescription.md
@@ -104,7 +104,7 @@ These are the mandatory identifiers per operation. In addition, a specific imple
 
 For set-fallback in particular, the ICCID identifies the target eSIM Profile to designate as fallback, while the EID, when supplied, identifies the eUICC on which to set it.
 
-When both an EID and an ICCID are provided and each is individually valid, but the ICCID does not correspond to an eSIM Profile installed on the eUICC identified by the EID, the request is rejected with `422 IDENTIFIER_MISMATCH`. Note that `404 IDENTIFIER_NOT_FOUND` is reserved for the case where an identifier cannot be matched at all (e.g. an unknown EID or ICCID), as distinct from a mismatch between two otherwise valid identifiers.
+When both an EID and an ICCID are provided and each is individually valid, but the ICCID does not correspond to an eSIM Profile installed on the eUICC identified by the EID, the request is rejected with `422 ESIM_PROFILE_MANAGEMENT.IDENTIFIER_MISMATCH`. Note that `404 IDENTIFIER_NOT_FOUND` is reserved for the case where an identifier cannot be matched at all (e.g. an unknown EID or ICCID), as distinct from a mismatch between two otherwise valid identifiers.
 
 ## Operation Status Retrieval
 

--- a/documentation/API_documentation/eSIM-Profile-Management_GeneralDescription.md
+++ b/documentation/API_documentation/eSIM-Profile-Management_GeneralDescription.md
@@ -96,13 +96,22 @@ Asynchronous operations have two status values: `ACCEPTED` and `COMPLETED`. The 
 
 
 **Usage:**
-- Enable/disable/delete/set-fallback require ICCID; EID may also be supplied to scope the operation to a specific eUICC
+- Enable/disable/delete/set-fallback require ICCID; the EID may also be supplied (see below)
 - Download requires EID (device targeting); the ICCID is assigned during download
-- Status retrieval accepts either EID (all profiles on the device) or ICCID (a specific profile)
+- Status retrieval accepts the EID (all profiles on the device), the ICCID (a specific profile), or both (see below)
 
-These are the mandatory identifiers per operation. In addition, a specific implementation may require both the EID and the ICCID to be passed together (e.g. to scope an operation to a particular device), even where only one is mandated above.
+These are the mandatory identifiers per operation. The optional EID is discussed below; note that a specific implementation may additionally require the EID even where only the ICCID is mandated above.
 
 For set-fallback in particular, the ICCID identifies the target eSIM Profile to designate as fallback, while the EID, when supplied, identifies the eUICC on which to set it.
+
+**When and why a consumer supplies both identifiers**
+
+Supplying both the EID and the ICCID together is always optional; providing only the mandatory identifier for an operation is fully supported. The ICCID identifies the target eSIM Profile, so the EID is not normally needed to determine which profile is meant. A consumer that has downloaded a profile already holds both identifiers — the EID it supplied at download and the ICCID returned in the response — so supplying the second identifier is never a means to discover an unknown value. It serves two purposes:
+
+- **Routing.** The API provider may not immediately know which device currently holds a given ICCID, and resolving that mapping can require additional interaction with the device. IoT deployments often avoid such interaction routinely to conserve device data and energy. Supplying the EID lets the provider route the operation to the target device directly, rather than resolving the ICCID first.
+- **Defensive assertion.** Supplying both asks the provider to confirm the pairing before acting: if the ICCID is not installed on the identified device, the request is rejected rather than applied to an unintended target.
+
+For status retrieval specifically: supplying only the EID returns all profiles on the device, supplying only the ICCID returns that single profile, and supplying both returns that profile subject to the same pairing assertion.
 
 When both an EID and an ICCID are provided and each is individually valid, but the ICCID does not correspond to an eSIM Profile installed on the eUICC identified by the EID, the request is rejected with `422 ESIM_PROFILE_MANAGEMENT.IDENTIFIER_MISMATCH`. Note that `404 IDENTIFIER_NOT_FOUND` is reserved for the case where an identifier cannot be matched at all (e.g. an unknown EID or ICCID), as distinct from a mismatch between two otherwise valid identifiers.
 


### PR DESCRIPTION
#### What type of PR is this?

* bug


#### Which issue(s) this PR fixes:

Fixes #53 

- Remove `IDENTIFIER_MISTMATCH`
- Corrected `ESimProfileForDownload` to only accept EID
- Clarifications in docs on the use of the dual `EID` and  `ICCID` identifiers

