### PR TITLE
docs: document operation state behaviour (#54)

### DIFF
--- a/code/API_definitions/esim-profile-management.yaml
+++ b/code/API_definitions/esim-profile-management.yaml
@@ -56,15 +56,13 @@ info:
 
     This preparation phase is **outside the scope** of the eSIM Management API.
 
-    # Error Handling
+    # Operation states
 
-    All operations that require device interaction (download, enable, disable, delete, set-fallback) are asynchronous and return 202 with an operationId on acceptance. Errors are reported as follows:
+    Operations that act on the device (download, enable, disable, delete, set-fallback) are asynchronous. A request is either rejected synchronously with a 4xx (no `operationId` issued), or accepted with `202`, an `operationId`, and `status: ACCEPTED`.
 
-    - **Synchronous errors (immediate 4xx)**: Failures detectable without device interaction are returned immediately. This includes authentication failures (401), authorization failures (403), unknown identifiers (404), state-precondition violations (409), malformed requests (400), and inapplicable service (422).
+    Once accepted, `status` moves from `ACCEPTED` to `COMPLETED`, which is terminal. The final result is carried in `result.outcome` (`SUCCESS` or `FAILED`), and a failure is described by `result.failureReason`. Which failures are detected before acceptance versus reported on the operation may evolve in future versions.
 
-    - **Asynchronous failures (202 → status: COMPLETED, result.outcome: FAILED)**: Failures that occur during device-side execution (e.g. device unreachable, OTA timeout, SM-DP+ error) are reported via the operation resource. Poll GET /operations/{operationId} to retrieve the outcome.
-
-    Operation status is retrieved by polling GET /operations/{operationId}. Event-based notifications are not supported in this version.
+    The API Consumer must poll GET /operations/{operationId} to observe completion. A `COMPLETED` operation is retrievable only for a provider-defined period, after which the endpoint returns `404`. Callbacks and event notifications are planned in future versions.
 
     <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
     # Authorization and authentication
@@ -504,7 +502,9 @@ paths:
         - eSIM Profile Operations
       summary: Retrieve operation information
       description: |
-        Retrieves detailed information about an eSIM Profile operation including status, results, and progress.
+        Retrieves detailed information about an eSIM Profile operation including its `status` and, once `COMPLETED`, its `result`.
+
+        The API Consumer polls this endpoint to observe the transition from `ACCEPTED` to `COMPLETED`. A `COMPLETED` operation remains retrievable only for a provider-defined period, after which this endpoint returns `404`.
 
         **Operation ID**: From any eSIM Profile operation response
       operationId: retrieveOperation

--- a/documentation/API_documentation/eSIM-Profile-Management_GeneralDescription.md
+++ b/documentation/API_documentation/eSIM-Profile-Management_GeneralDescription.md
@@ -77,7 +77,9 @@ eSIM Profiles have two states: DISABLED and ENABLED.
 
 ## States of operations
 
-Asynchronous operations have two status values: `ACCEPTED` and `COMPLETED`. The `status` reflects the operation lifecycle only; when an operation reaches `COMPLETED`, the `result.outcome` field carries the final outcome (`SUCCESS` or `FAILED`).
+An asynchronous request has one of two outcomes. It is either rejected synchronously with a 4xx (400, 401, 403, 404, 409, or 422), in which case no `operationId` is issued, or it is accepted with a `202`, an `operationId`, and `status: ACCEPTED`. A `422 SERVICE_NOT_APPLICABLE` is one of several possible synchronous rejections, not the only one.
+
+Once accepted, the operation has two status values: `ACCEPTED` and `COMPLETED`. The `status` reflects the operation lifecycle only, and `COMPLETED` is terminal. The final result is carried in `result.outcome` (`SUCCESS` or `FAILED`). A failure is described by a human-readable `result.failureReason`. Today a `FAILED` outcome is typically a device-side failure, such as the device being unreachable, an OTA timeout, or an SM-DP+ error. Which failures are detected before acceptance (a 4xx) versus after acceptance (on the operation) may evolve in future versions, as may the addition of a machine-readable failure code.
 
 **Figure**: lifecycle of an operation
 
@@ -85,6 +87,8 @@ Asynchronous operations have two status values: `ACCEPTED` and `COMPLETED`. The 
 
 - `ACCEPTED`: Operation queued for processing
 - `COMPLETED`: Operation finished (check `result.outcome` for `SUCCESS` or `FAILED`)
+
+The API Consumer must poll `GET /operations/{operationId}` to observe the transition to `COMPLETED`. There is no push or callback notification in this version; callbacks and event notifications may be added in a future version. A `COMPLETED` operation remains retrievable only for a provider-defined period; once purged, the endpoint returns `404`, so consumers must not rely on long-term availability.
 
 
 
@@ -111,7 +115,9 @@ When both an EID and an ICCID are provided and each is individually valid, but t
 The status and result of an asynchronous operation are retrieved by polling:
 - GET /esim-profile-management/operations/{operationId}
 
-Event-based notifications (e.g. CloudEvents callbacks to a sink URL) are not supported in this version.
+The consumer polls until `status` is `COMPLETED`, then reads `result.outcome`. The operation resource may later return `404` once it has been purged (see States of operations).
+
+Event-based notifications (e.g. CloudEvents callbacks to a sink URL) are not supported in this version and may be added in a future version.
 
 ## Security and Authorization
 


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### Which issue(s) this PR fixes:

Fixes #54 

#### Special notes for reviewers:

The operation state model was underdocumented. Now added in API yaml and General Description the following:

* Clarified 4xx errors and errors after ACCEPTED
* clarified polling on GET /operations/{operationId};  
* stated COMPLETED operation are retrievable only for a provider-defined period, after which it returns 404. 


I have left some of wording choice on sync / async errors deliberately loose for a next version.